### PR TITLE
feat(ui): panelCard 도입 및 추천/퍼스널컬러를 검색 톤(#F2F2F2/white)으로 통일

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -8,6 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Thermometer, Palette, Search, Shirt } from "lucide-react";
 
+/* 공용 패널 톤: 흰색 카드 + 은은한 테두리(다른 페이지와 동일) */
+const panelCard =
+  "rounded-2xl bg-white dark:bg-neutral-900 border border-neutral-200/80 dark:border-neutral-800/80 shadow-sm";
+
 /* ====== Footer ====== */
 function LiteFooter() {
   return (
@@ -50,9 +54,8 @@ function FeatureCard({
   return (
     <Link href={href} className="block group">
       <Card
-        className="h-full bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800
-                   shadow-sm transition-all rounded-2xl
-                   motion-safe:group-hover:-translate-y-1 motion-safe:group-hover:shadow-lg"
+        className={`${panelCard} h-full transition-all
+                    motion-safe:group-hover:-translate-y-1 motion-safe:group-hover:shadow-lg`}
       >
         <div className="flex flex-col items-center text-center px-8 py-8">
           <div
@@ -150,7 +153,8 @@ export default function HomePage() {
   const brandWrapRef = useRef(null);
 
   return (
-    <main className="min-h-screen bg-white dark:bg-neutral-900 flex flex-col">
+    /* ✅ 페이지 배경을 neutral-50로 통일 */
+    <main className="min-h-screen bg-neutral-50 dark:bg-neutral-900 flex flex-col">
       <Header />
 
       <section className="mx-auto max-w-6xl px-4 py-12 flex-1">

--- a/app/personal-color/page.js
+++ b/app/personal-color/page.js
@@ -13,6 +13,10 @@ import Link from "next/link"
 
 const seasonLabel = { spring: "봄 웜", summer: "여름 쿨", autumn: "가을 웜", winter: "겨울 쿨" }
 
+// ✅ 카드(흰색) 톤 — 검색 페이지와 동일
+const panelCard =
+  "rounded-2xl bg-white dark:bg-neutral-900 border border-neutral-200/80 dark:border-neutral-800/80 shadow-sm"
+
 export default function PersonalColorWizardPage() {
   const analyzerRef = useRef(new PersonalColorAnalyzer())
   const analyzer = analyzerRef.current
@@ -25,14 +29,8 @@ export default function PersonalColorWizardPage() {
   const current = analyzer.questions[step]
   const progress = Math.round((Object.keys(answers).length / total) * 100)
 
-  const choose = (val) => {
-    setAnswers((p) => ({ ...p, [current.id]: val }))
-  }
-
-  const next = () => {
-    if (step < total - 1) setStep((s) => s + 1)
-    else finalize()
-  }
+  const choose = (val) => setAnswers((p) => ({ ...p, [current.id]: val }))
+  const next = () => (step < total - 1 ? setStep((s) => s + 1) : finalize())
   const prev = () => setStep((s) => Math.max(0, s - 1))
 
   const finalize = () => {
@@ -46,7 +44,7 @@ export default function PersonalColorWizardPage() {
   const save = () => result && setUserPersonalColor(seasonLabel[result])
 
   const QuizView = () => (
-    <Card className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800">
+    <Card className={panelCard}>
       <CardHeader className="pb-3">
         <CardTitle className="text-neutral-900 dark:text-white">퍼스널 컬러 진단</CardTitle>
         <CardDescription className="text-neutral-600 dark:text-neutral-300">
@@ -71,7 +69,7 @@ export default function PersonalColorWizardPage() {
                 className={`flex items-center gap-2 rounded-md border px-3 py-2 transition ${
                   answers[current.id] === op.value
                     ? "border-[#0B64FE] bg-[#0B64FE]/5 dark:bg-[#0B64FE]/10"
-                    : "border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-800/80"
+                    : "border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-800/80"
                 }`}
               >
                 <RadioGroupItem value={op.value} id={`${current.id}-${op.value}`} />
@@ -110,7 +108,7 @@ export default function PersonalColorWizardPage() {
   )
 
   const ResultView = () => (
-    <Card className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800">
+    <Card className={panelCard}>
       <CardHeader>
         <CardTitle className="text-neutral-900 dark:text-white flex items-center gap-2">
           <CheckCircle2 className="h-5 w-5 text-[#0B64FE]" />
@@ -166,7 +164,8 @@ export default function PersonalColorWizardPage() {
   )
 
   return (
-    <main className="min-h-screen bg-white dark:bg-neutral-900">
+    // ✅ 페이지 배경: 검색과 동일(#F2F2F2)
+    <main className="min-h-screen bg-[#F2F2F2] dark:bg-neutral-900">
       <Header />
       <section className="mx-auto max-w-4xl px-4 py-10">{!done ? <QuizView /> : <ResultView />}</section>
     </main>


### PR DESCRIPTION
## 개요
- 검색 페이지의 톤(페이지 배경 **#F2F2F2**, 카드 배경 **white**)을 기준으로 **추천(/recommend)**, **퍼스널컬러(/personal-color)** 화면을 동일하게 정리
- 재사용 가능한 **공용 카드 스타일(panelCard)** 도입으로 UI 일관성 확보
- Tailwind/PostCSS 설정을 현재 지원 버전에 맞게 정리하여 빌드 경고/오류 감소

## 상세 내용
- **UI**
  - 페이지 배경(라이트): `#F2F2F2`로 변경, 다크 모드는 기존 유지
  - 카드: `bg-white + border-neutral-200 + shadow-sm`를 **panelCard**로 공통화
  - 라디오/컨트롤 **비선택 배경을 `bg-white`**로 통일(hover 톤 유지)
  - 적용 범위: `/recommend`, `/personal-color`

- **빌드/설정**
  - `tailwind.config.js` 추가/정리(내용 경로, theme 확장 정돈)
  - `globals.css`의 `@tailwind` 지시자 순서/주석 정리
  - `postcss.config.mjs` 제거 → `postcss.config.js`로 통합(CJS)
  - Tailwind/PostCSS **버전 정렬**(프로젝트 지원 범위에 맞춰 다운그레이드/정리)
